### PR TITLE
add assembly-stats rule

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -9,3 +9,6 @@ output_dir: output
 #Recommended flags
 #Read trimming - default = True
 trim_reads: True
+
+#Assembly-stats: To disable, set to False
+assembly_stats: True #False

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -21,7 +21,9 @@ if config['input_type'] not in ['raw_reads', 'filtered_reads', 'assemblies']:
 elif config['input_type'] == 'raw_reads':
     include: "rules/shovill.smk"
 
-
+#Assembly stats
+if config['assembly_stats'] != False:
+    include: "rules/assembly-stats.smk"
 
     
 

--- a/workflow/rules/assembly-stats.smk
+++ b/workflow/rules/assembly-stats.smk
@@ -1,0 +1,28 @@
+rule run_assembly_stats:
+    input:
+        #Input assembly
+        assembly=config['output_dir']+"/shovill/{sample}.{assembler}.contigs.fa",
+    output:
+        #Assembly statistics
+        assembly_stats=config['output_dir']+"/assembly-stats/{assembler}/{sample}.txt"
+    params:
+        # Tab delimited output, with a header, is set as the default. Other options are available:
+        #   -l <int>
+        #       Minimum length cutoff for each sequence.
+        #       Sequences shorter than the cutoff will be ignored [1]
+        #   -s
+        #       Print 'grep friendly' output
+        #   -t
+        #       Print tab-delimited output
+        #   -u
+        #       Print tab-delimited output with no header line
+        # If you want to add multiple options just delimit them with a space.
+        # Note that you can only pick one output format
+        # Check https://github.com/sanger-pathogens/assembly-stats for more details
+        extra="-t",
+    log:
+        "logs/{assembler}/{sample}.assembly-stats.log",
+    threads: 1
+    wrapper:
+        #"0.2.0/bio/assembly-stats"
+        "https://raw.githubusercontent.com/maxlcummins/snakemake-wrappers/assembly-stats/bio/assembly-stats/wrapper.py"


### PR DESCRIPTION
Added assembly-stats rule. Currently using a forked snakemake wrapper path as I am awaiting approval of a pull request into the official snakemake-wrappers repo. I will need to change the wrapper specification when it is eventually approved by snakemake-wrapper repo admin.